### PR TITLE
allow for macros (%{}) at the start of exists

### DIFF
--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -21,7 +21,7 @@ pub(crate) const MECHANISM_MX_PATTERN: &str =
 pub(crate) const MECHANISM_PTR_PATTERN: &str = r"(?i)^(?P<qualifier>[+?~-])?ptr(?:$|[^a-z./])(?P<mechanism>(?:[[:word:]]+\.)*[[:word:]]+
 ?)?$";
 pub(crate) const MECHANISM_EXISTS_PATTERN: &str =
-    r"(?i)^(?P<qualifier>[+?~-])?exists:(?:$|)(?P<mechanism>\w.*)";
+    r"(?i)^(?P<qualifier>[+?~-])?exists:(?:$|)(?P<mechanism>(%|\w).*)";
 // All Regex is currently not being used.
 pub(crate) const MECHANISM_ALL_PATTERN: &str = r"^(?P<qualifier>[+?~-])?all(?P<mechanism>\s)?$";
 // Create a new mechanism for a matched regular expression.

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -21,7 +21,7 @@ pub(crate) const MECHANISM_MX_PATTERN: &str =
 pub(crate) const MECHANISM_PTR_PATTERN: &str = r"(?i)^(?P<qualifier>[+?~-])?ptr(?:$|[^a-z./])(?P<mechanism>(?:[[:word:]]+\.)*[[:word:]]+
 ?)?$";
 pub(crate) const MECHANISM_EXISTS_PATTERN: &str =
-    r"(?i)^(?P<qualifier>[+?~-])?exists:(?:$|)(?P<mechanism>(%|\w).*)";
+    r"(?i)^(?P<qualifier>[+?~-])?exists:(?P<mechanism>(?:%|\w).*)";
 // All Regex is currently not being used.
 pub(crate) const MECHANISM_ALL_PATTERN: &str = r"^(?P<qualifier>[+?~-])?all(?P<mechanism>\s)?$";
 // Create a new mechanism for a matched regular expression.

--- a/src/mechanism/tests/mechanism/fromstr/exists.rs
+++ b/src/mechanism/tests/mechanism/fromstr/exists.rs
@@ -9,6 +9,13 @@ fn default() {
     assert_eq!(m.kind().is_exists(), true);
     assert_eq!(m.raw(), "example.com");
     assert_eq!(m.to_string(), input);
+
+    let input = "exists:%{i}._i.example.com";
+
+    let m: Mechanism<String> = input.parse().unwrap();
+    assert_eq!(m.kind().is_exists(), true);
+    assert_eq!(m.raw(), "%{i}._i.example.com");
+    assert_eq!(m.to_string(), input);
 }
 #[test]
 fn with_pass() {


### PR DESCRIPTION
Modify the regex parsing exists to include %|\w so exists with macros at the start will be captured correctly:

%{i}._i.example.com